### PR TITLE
ANSI Support for Windows 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,31 @@ bold, bg, under, strike, italic
 info, que, run, bad, good
 ```
 
-**Note:** Windows does not support ANSI escape sequences so the colors will not be printed in command prompt.
+### Windows 10
+
+**Note:** Windows 10 do support ANSI escape sequences, so the colors will be printed in command prompt if you enable them as follows
+In other versions of Windows, they won't be supported (hue_enable_windows_support returns False in that case).
+
+```python
+from huepy import *
+
+# Has hue_ since common use is from huepy import *
+if not hue_enable_windows_support():
+    # Disables ANSI codes if the prompt doesn't support it
+    hue_disable()
+
+print(red("a"), blue("b"))
+```
+
+Since sometimes the test is negative for some prompts (for example PyCharm Terminal), you may choose to only support Windows prompts that support it
+and don't disable the ansi codes
+
+```python
+from huepy import *
+hue_enable_windows_support()
+
+print(red("a"), blue("b"))
+```
 
 ### Contribution
 

--- a/hue.py
+++ b/hue.py
@@ -33,11 +33,76 @@ COMMANDS = {
     'strike': '09',
 }
 
+enabled = True
+
 
 def _gen(string, prefix, key):
+    if not enabled:
+        return string
     colored = prefix if prefix else string
     not_colored = string if prefix else ''
     return '\033[{}m{}\033[0m{}'.format(key, colored, not_colored)
+
+
+def hue_enable_windows_support():
+    """
+    Enables ANSI Support on Windows 10, disables ansi characters otherwise
+    :return Whether can enable windows support
+    """
+    import os
+    if os.name != "nt":
+        # Return true on anything other than windows
+        return True
+    try:
+        # https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#span-idsamplesspanspan-idsamplesspanspan-idsamplesspansamples
+        # https://docs.microsoft.com/en-us/windows/console/getstdhandle
+        # https://docs.microsoft.com/en-us/windows/console/getconsolemode
+        # https://docs.microsoft.com/en-us/windows/console/setconsolemode
+
+        # Also, logic from https://github.com/ogham/rust-ansi-term/blob/master/src/windows.rs, was the simplest to fit into python
+
+        import ctypes
+        import ctypes.wintypes
+
+        kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+        error_code = kernel32.GetLastError()
+        if error_code != 0:
+            return False
+        kernel32.GetStdHandle.restype = ctypes.wintypes.HANDLE
+
+        STD_OUTPUT_HANDLE = -11
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004
+
+        hout = kernel32.GetStdHandle(STD_OUTPUT_HANDLE)  # STD_OUTPUT_HANDLE = -11
+        error_code = kernel32.GetLastError()
+        if error_code != 0:
+            return False
+        dwOriginalOutMode = ctypes.c_uint32(0)
+        kernel32.GetConsoleMode(hout, ctypes.byref(dwOriginalOutMode))
+        error_code = kernel32.GetLastError()
+        if error_code != 0:
+            return False
+        dwOriginalOutMode = dwOriginalOutMode.value
+        # if not enabled
+        if dwOriginalOutMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING == 0:
+            kernel32.SetConsoleMode(hout, ctypes.c_uint32(dwOriginalOutMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+            error_code = kernel32.GetLastError()
+            if error_code != 0:
+                return False
+
+        return True
+    except ImportError:
+        return False
+
+
+def hue_enable():
+    global enabled
+    enabled = True
+
+
+def hue_disable():
+    global enabled
+    enabled = False
 
 
 for key, val in COMMANDS.items():
@@ -45,4 +110,4 @@ for key, val in COMMANDS.items():
     prefix = val[1] if isinstance(val, tuple) else ''
     locals()[key] = lambda s, prefix=prefix, key=value: _gen(s, prefix, key)
 
-__all__ = list(COMMANDS.keys())
+__all__ = list(COMMANDS.keys()) + ['hue_enable_windows_support', 'hue_enable', 'hue_disable']


### PR DESCRIPTION
Starting from Window 10, Windows now supports ANSI codes in the command prompt when requested by the developer (with SetConsoleMode). 

Added a method called hue_enable_windows_support for coloring of output buffer of the console based on [MSDN sample code](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#span-idsamplesspanspan-idsamplesspanspan-idsamplesspansamples) and [rust-ansi-term implementation](https://github.com/ogham/rust-ansi-term/blob/master/src/windows.rs). When hue_enable_windows_support is called (named with hue_ since most common use is with from huepy import *), it tries to enable it and returns whether it could enable the Windows support (always true on systems other than Windows).

Also added hue_enable, hue_disable methods for convenience, so that someone can try to enable the windows support and disable if it was not successful.