### PR TITLE
Port hue to Python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ![Hue Logo](https://i.imgur.com/Pxe9la8.png)
 
-Hue provides a minimal and powerful interface to print colored text and labels in the terminal.\
-It works with Python 2 as well as Python 3.
+Hue provides a minimal and powerful interface to print colored text and labels
+in the terminal.\ It works with Python 2 as well as Python 3.
 
-What makes hue better than other coloring libraries? [Here's a comparison.](#why-hue)
+What makes hue better than other coloring libraries? [Here's a
+comparison.](#why-hue)
 
 ## Supported Stuff
 
@@ -42,7 +43,7 @@ from huepy import *
 Printing colored text is as simple as doing
 
 ```python
-print red('This string is red')
+print(red('This string is red'))
 ```
 
 Easy right?
@@ -50,13 +51,13 @@ But what if you want to print italic text?
 You can simply do this
 
 ```python
-print italic('This string is in italic')
+print(italic('This string is in italic'))
 ```
 
 You can also combine styles and colors
 
 ```python
-print bold(red('This string is bold and red'))
+print(bold(red('This string is bold and red')))
 ```
 
 Output:
@@ -67,7 +68,7 @@ I have been using these labels in projects as a minimal output schema.\
 If some error occured in your program or something else bad happened you don't need to print the whole line in red. With hue, you can simply do this
 
 ```python
-print bad('An error occured.')
+print(bad('An error occured.'))
 ```
 
 Take a look at the output of all the labels
@@ -102,29 +103,34 @@ Lets print a red colored string in popular coloring libraries:
 - Colorama
 ```python
 from colorama import Fore
-print Fore.RED + 'This string is red'
+print(Fore.RED + 'This string is red')
 ```
 - Termcolor
 ```python
 import sys
 from termcolor import colored, cprint
-print colored('This string is red', 'red')
+print(colored('This string is red', 'red'))
 ```
 - Hue
 ```python
 from hue import *
-print red('This string is red')
+print(red('This string is red'))
 ```
 Here's comparison table:
 
-||Hue|Colorama|Termcolor|
-|---|---|--------|---------|
-|Compatibility|Unix & Windows 10|Unix & Windows|Unix|
-|Ease of use|10/10|4/10|5/10|
-|Bright Colors|Yes|No|No|
+|             |Hue              |Colorama      |Termcolor|
+|-------------|-----------------|--------------|---------|
+|Compatibility|Unix & Windows 10|Unix & Windows|Unix     |
+|Ease of use  |10/10            |4/10          |5/10     |
+|Bright Colors|Yes              |No            |No       |
 
-**Note:** Colorama and Termcolor print bold styled strings when asked for bright colored strings. On the other hand, Hue supports both bright and bold strings. Also the *Ease to use* ratings are a result of my own experience and may differ for others.
+**Note:** Colorama and Termcolor print bold styled strings when asked for
+bright colored strings. On the other hand, Hue supports both bright and bold
+strings. Also the *Ease to use* ratings are a result of my own experience and
+may differ for others.
 
 ### Contribution
 
-The only thing I think **Hue** needs is better windows compatibility. So if you can start a pull request for windows support that would be great. Additional colors and labels will be appreciated too.
+The only thing I think **Hue** needs is better windows compatibility. So if
+you can start a pull request for windows support that would be great.
+Additional colors and labels will be appreciated too.

--- a/huepy/__init__.py
+++ b/huepy/__init__.py
@@ -1,8 +1,8 @@
-from huepy.hue import *
+from hue import COMMANDS
 
+__all__ = list(COMMANDS.keys())
+__version__ = '1.0.1'
 
-__all__ = ['bad', 'bg', 'black', 'blue', 'bold', 'cyan', 'good', 'green',
-           'grey', 'info', 'italic', 'lightblue', 'lightcyan', 'lightgreen',
-           'lightpurple', 'lightred', 'orange', 'purple', 'que', 'red', 'run',
-           'strike', 'under', 'white', 'yellow']
-__version__ = '1.0.0'
+if __name__ == '__main__':
+    print('All commands: ', __all__)
+    print('Current version: ', __version__)

--- a/huepy/hue.py
+++ b/huepy/hue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import ctypes
 import platform
@@ -44,12 +44,10 @@ COMMANDS = {
 def _gen(string, prefix, key):
     colored = prefix if prefix else string
     not_colored = string if prefix else ''
-    return u'\033[{}m{}\033[0m{}'.format(key, colored, not_colored)
+    return '\033[{}m{}\033[0m{}'.format(key, colored, not_colored)
 
 
 for key, val in COMMANDS.items():
     value = val[0] if isinstance(val, tuple) else val
     prefix = val[1] if isinstance(val, tuple) else ''
     locals()[key] = lambda s, prefix=prefix, key=value: _gen(s, prefix, key)
-
-__all__ = list(COMMANDS.keys())

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,9 @@
-import codecs
-import os
-import re
+import huepy
 
 from setuptools import find_packages, setup
 
-
-def abs_path(*relative_path_parts):
-    return os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                        *relative_path_parts)
-
-
 name = 'huepy'
-
-with codecs.open(abs_path(name, '__init__.py'), 'r', 'utf-8') as fp:
-    try:
-        version = re.findall(r"^__version__ = '([^']+)'.*?$",
-                             fp.read(), re.M)[0]
-    except IndexError:
-        raise RuntimeError('Unable to determine version.')
+version = huepy.__version__
 
 setup(
     name=name,


### PR DESCRIPTION
This PR ports hue to Python3. There were not many changes needed.  The only
port changes are removing the string-prefix `u`, because every string in
Python3 is unicode. Also the shebang in `huepy/hue.py` is changed from
`#!/usr/bin/env python` to `#!/usr/bin/env python3`.