### PR TITLE
Fix hue import with python 3

### DIFF
--- a/huepy/__init__.py
+++ b/huepy/__init__.py
@@ -1,4 +1,4 @@
-from hue import COMMANDS
+from .hue import COMMANDS
 
 __all__ = list(COMMANDS.keys())
 __version__ = '1.0.1'


### PR DESCRIPTION
During setup build with python3.8, the error `No module named 'hue'` appears.
This commit prevent this error to shows up.
