### PR TITLE
Adding a rainbow function

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ blue, lightblue, purple, light purple, orange, yellow
 #### List of all styles
 
 ```python
-bold, bg, under, strike, italic
+bold, bg, under, strike, italic, rainbow
 ```
 
 #### List of all labels

--- a/huepy/__init__.py
+++ b/huepy/__init__.py
@@ -3,7 +3,8 @@ from .huepy import *
 __all__ = ['bad', 'bg', 'black', 'blue', 'bold', 'cyan', 'good', 'green',
            'grey', 'info', 'italic', 'lblue', 'lightblue', 'lcyan', 'lgreen',
            'lightgreen', 'lpurple', 'lightpurple', 'lred', 'lightred','orange',
-           'purple', 'que', 'red', 'run','strike', 'under', 'white', 'yellow']
+           'purple', 'que', 'red', 'run','strike', 'under', 'white', 'yellow',
+           'rainbow']
 
 __version__ = '1.2.1'
 

--- a/huepy/huepy.py
+++ b/huepy/huepy.py
@@ -9,6 +9,13 @@ if platform.system() == 'Windows':
 
 print_mode = False
 
+
+def rainbow(string):
+    colors = [val for key,val in COMMANDS.items() if isinstance(val,int)]
+    out = "".join([_gen(string[i],'',colors[i%len(colors)]) for i in range(len(string))])
+    return out
+
+
 COMMANDS = {
     # Lables
     'info': (33, '[!] '),
@@ -45,13 +52,20 @@ COMMANDS = {
     'italic': '3',
     'under': '4',
     'strike': '09',
+
+    # Special
+    'rainbow' : rainbow,
 }
 
 
 def _gen(string, prefix, key):
     colored = prefix if prefix else string
     not_colored = string if prefix else ''
-    result = '\033[{}m{}\033[0m{}'.format(key, colored, not_colored)
+    is_special = callable(key)
+    if is_special:
+        result = key(string)
+    else:
+        result = '\033[{}m{}\033[0m{}'.format(key, colored, not_colored)
     if print_mode:
         print(result)
     else:

--- a/huepy/huepy.py
+++ b/huepy/huepy.py
@@ -10,7 +10,7 @@ if platform.system() == 'Windows':
 print_mode = False
 
 
-def rainbow(string):
+def _rainbow(string):
     colors = [val for key,val in COMMANDS.items() if isinstance(val,int)]
     out = "".join([_gen(string[i],'',colors[i%len(colors)]) for i in range(len(string))])
     return out
@@ -54,7 +54,7 @@ COMMANDS = {
     'strike': '09',
 
     # Special
-    'rainbow' : rainbow,
+    'rainbow' : _rainbow,
 }
 
 


### PR DESCRIPTION
This adds a rainbow function that colors a string in all available colors:
![rainbow](https://user-images.githubusercontent.com/1621311/94985785-c2998000-0559-11eb-998f-20119754e287.png)

For implementing this I added a check to `_gen` to see if the value provided is a callable function. This also enables other custom functions to be added to the `COMMANDS` dict.