### PR TITLE
setup.py: drop data_files, installs LICENSE to incorrect place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
     keywords='hue, color, terminal color, colorama',
     packages=find_packages(),
     py_modules=['huepy'],
-    data_files=[('', ['LICENSE'])],
     include_package_data=True,
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
The data_files statement in the setup() calls installs the LICENSE file in the wrong place: in /usr/LICENSE, or even /LICENSE depending on the configuration.

So let's drop this, and let setuptools install the LICENSE file automatically: since setuptools v56, the license_files attribute is automatically assigned to a default value, which includes "LICENSE", so there is in fact nothing to do to the get the LICENSE file installed at the correct location. See
https://setuptools.pypa.io/en/latest/history.html#v56-0-0.